### PR TITLE
Fix/ Procedure triggers

### DIFF
--- a/functions/ecom.config.js
+++ b/functions/ecom.config.js
@@ -190,12 +190,13 @@ procedures.push({
     // Receive notifications when products/variations stock quantity changes:
     {
       resource: 'products',
+      subresource: null,
       field: 'quantity',
     },
     {
       resource: 'products',
-      subresource: 'variations',
-      field: 'quantity'
+      subresource: null,
+      field: 'price',
     },
     // Feel free to create custom combinations with any Store API resource, subresource, action and field.
   ],


### PR DESCRIPTION
Não precisamos (ou não devemos precisar) de trigger por variação, quando a quantidade da variação é alterada há uma replicação para a quantidade do produto principal logo em seguida, se houver trigger para ambos o app receberá webhooks duplicados para "o mesmo" evento.
Desta forma também evitamos receber um webhook pra cada variação se várias variações forem alteradas, receberemos apenas o webhook relativo à atualização do produto e todas as variações poderão ser tratadas de uma vez só.
Como estamos implementando também alerta para desconto, em teoria também precisamos de trigger por alteração de preço.